### PR TITLE
Generate collapsible property overview

### DIFF
--- a/attribute-uebersicht.html
+++ b/attribute-uebersicht.html
@@ -1,0 +1,531 @@
+<html><head><meta charset="UTF-8"><style>body{font-family:sans-serif;} details{margin-left:20px;} .property summary{font-weight:bold;} .prop-content{margin-left:20px;} </style></head><body>
+<h1>Wand</h1>
+<details>
+<summary>Pset_HRB</summary>
+<details class="property">
+<summary>Länge</summary>
+<div class="prop-content"><strong>Einheit:</strong> [mm]</div>
+</details>
+<details class="property">
+<summary>Breite</summary>
+<div class="prop-content"><strong>Einheit:</strong> [mm]</div>
+</details>
+<details class="property">
+<summary>Höhe</summary>
+<div class="prop-content"><strong>Einheit:</strong> [mm]</div>
+</details>
+<details class="property">
+<summary>Radius</summary>
+<div class="prop-content"><strong>Einheit:</strong> [mm]</div>
+</details>
+<details class="property">
+<summary>Durchmesser</summary>
+<div class="prop-content"><strong>Einheit:</strong> [mm]</div>
+</details>
+<details class="property">
+<summary>Neigung</summary>
+<div class="prop-content"><strong>Einheit:</strong> [Grad]</div>
+</details>
+<details class="property">
+<summary>Betonart </summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> Normalbeton, Schwerbeton, Leichtbeton</div>
+</details>
+<details class="property">
+<summary>Bewehrungsgrad</summary>
+<div class="prop-content"><strong>Einheit:</strong> [%]</div>
+</details>
+<details class="property">
+<summary>Bewehrung nach DIN 488</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>[Typ] [Kurzbezeichnung] Bsp.: Rippenstahlmatte Q257A, Stabstahl B500A</div>
+</details>
+</details>
+<details class="property">
+<summary>Bewehrungstahl Oberfläche</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> gerippt, glatt, profiliert</div>
+</details>
+<details class="property">
+<summary>Druckfestigkeitsklasse (DIN EN 206)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> C8/10, C12/15, C16/20, C20/25, C25/30, C30/37, C35/45, C40/50, C45/55, C50/60, C55/67, C60/75, C70/85, C80/95, C90/105, C100/115</div>
+</details>
+<details class="property">
+<summary>Erforderliche Nachbehandlung</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> Ja/Nein</div>
+</details>
+<details class="property">
+<summary>Expositionsklasse (DIN EN 206)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> XC1, XC2, XC3, XC4, XD1, XD2, XD3, XS1, XS2, XS3, XF1, XF2, XF3, XF4, XA1, XA2, XA3</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>(Bsp.: XC1)</div>
+</details>
+</details>
+<details class="property">
+<summary>Klasse des Chloridgehalts (DIN EN 206)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> Cl 0,10, Cl 0,20, Cl 0,40</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Maximal zulässiger Chloridgehalt im Beton – bezogen auf die Zementmasse (Bsp.: Cl 0,20)</div>
+</details>
+</details>
+<details class="property">
+<summary>Korngrößenbereich Dmin/Dmax</summary>
+<div class="prop-content"><strong>Einheit:</strong> [mm]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>z.B.: 8/16 mm</div>
+</details>
+</details>
+<details class="property">
+<summary>Oberflächenbehandlung</summary>
+</details>
+<details class="property">
+<summary>RC Zuschlag</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> Ja/Nein</div>
+</details>
+<details class="property">
+<summary>RC Zuschlag Anteil</summary>
+<div class="prop-content"><strong>Einheit:</strong> [%]</div>
+</details>
+<details class="property">
+<summary>RC Zuschlag Materialart</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> RC 1, RC 2, RC 3, RC G, RC A, RC S, RC B</div>
+</details>
+<details class="property">
+<summary>Wasser-Zement-Wert</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>z.B.: 0,40</div>
+</details>
+</details>
+<details class="property">
+<summary>Normalkraft N</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kN]</div>
+</details>
+<details class="property">
+<summary>Querkraft Q</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kN]</div>
+</details>
+<details class="property">
+<summary>Moment M</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kNm]</div>
+</details>
+</details>
+<details>
+<summary>Pset_Ausnutzung</summary>
+<details class="property">
+<summary>Ausnutzung</summary>
+<div class="prop-content"><strong>Einheit:</strong> [%]</div>
+</details>
+<details class="property">
+<summary>Ausnutzung warm</summary>
+<div class="prop-content"><strong>Einheit:</strong> [%]</div>
+</details>
+<details class="property">
+<summary>Ausnutzung kalt</summary>
+<div class="prop-content"><strong>Einheit:</strong> [%]</div>
+</details>
+</details>
+<details>
+<summary>Pset_Tragfähigkeit_kN</summary>
+<details class="property">
+<summary>Charakteristische Tragfähigkeit senkrecht (inkl. Eigengewicht)</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kN]</div>
+</details>
+<details class="property">
+<summary>Charakteristische Tragfähigkeit horizontal</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kN]</div>
+</details>
+</details>
+<details>
+<summary>Pset_Tragfähigkeit_kN/m</summary>
+<details class="property">
+<summary>Charakteristische Tragfähigkeit senkrecht (inkl. Eigengewicht)</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kN/m]</div>
+</details>
+<details class="property">
+<summary>Charakteristische Tragfähigkeit horizontal</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kN/m]</div>
+</details>
+</details>
+<details>
+<summary>Pset_Tragfähigkeit_kN/m2</summary>
+<details class="property">
+<summary>Charakteristische Tragfähigkeit senkrecht (inkl. Eigengewicht)</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kN/m2]</div>
+</details>
+<details class="property">
+<summary>Charakteristische Tragfähigkeit horizontal</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kN/m2]</div>
+</details>
+</details>
+<details>
+<summary>Pset_Bemessungswerte</summary>
+<details class="property">
+<summary>Spannungen</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> σx = […]; σz = [...]; τxy = [...]</div>
+<div class="prop-content"><strong>Einheit:</strong> [N/mm²]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Bsp.: σx = 12.5; σz = 8.4; τxy = 3.2</div>
+</details>
+</details>
+<details class="property">
+<summary>Berechnete Bauteilabmessungen 3D</summary>
+<div class="prop-content"><strong>Einheit:</strong> [mm*mm*mm]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Breite * Höhe * Länge z.B. für Stützen</div>
+</details>
+</details>
+<details class="property">
+<summary>Berechnete Bauteilabmessungen 2D</summary>
+<div class="prop-content"><strong>Einheit:</strong> [mm*mm]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Breite * Höhe z.B. für Beplankungen</div>
+</details>
+</details>
+<details class="property">
+<summary>Maßgebender Nachweis</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> Biegung, Schub, Druck, Zug, Knicken, Verformung, Schwingung</div>
+</details>
+<details class="property">
+<summary>Abdichtungsklasse (DIN 18533/18534)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> W0-I, W1-I, W2-I, W3-I, W1-E, W2.1-E, W2.2-E, W3-E, W4-E</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Klassifizierung der Abdichtungsbeanspruchung gemäß DIN 18533 (erdberührte Bauteile) oder DIN 18534 (Innenräume)</div>
+</details>
+</details>
+<details class="property">
+<summary>Anforderungen an Feuerwiderstandklasse (DIN EN 13501)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> RE  15, 20, 30, 45, 60, 90, 120, 180, 240, 360
+REI 15, 20, 30, 45, 60, 90, 120, 180, 240, 360</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Vorgabe der erforderlichen Feuerwiderstandsklasse eines Bauteils gemäß bauordnungsrechtlicher Anforderungen, z. B. durch Architekt oder Brandschutzkonzept.</div>
+</details>
+</details>
+<details class="property">
+<summary>Aussparungen (wie abbilden)?!</summary>
+</details>
+<details class="property">
+<summary>Bauabschnitt</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>01,02,03,04,05, …</div>
+</details>
+</details>
+<details class="property">
+<summary>Bauteilschicht</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>5,4,3,2,1,0,-1,-2,-3,-4,-5</div>
+</details>
+</details>
+<details class="property">
+<summary>Baustoffklasse (DIN EN 13501)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> A1, A2, B, C, D, E, F</div>
+</details>
+<details class="property">
+<summary>Bauteilzugehörigkeits-Nr.</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> XX_XX_XXX_XX</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>AW_EG_001_01, IW_1.OG_001_01, DA_001_01; Modulbau: AW_EG_A_001_01; AW = Außenwand, IW = Innenwand, DA = Dach, DE = Decke, B = Binder</div>
+</details>
+</details>
+<details class="property">
+<summary>Bauliche Zulassung / Prüfzeugnis</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Dokumentennummer einer bauaufsichtlichen Zulassung, eines Prüfzeugnisses oder einer technischen Bewertung (z. B. AbZ, ETA, Prüfbericht). Z.B. ETA-21/0005, AbZ 123456</div>
+</details>
+</details>
+<details class="property">
+<summary>Eindeutige Bauteilbezeichnung</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>T_EG_001, T_1.OG_001; T = Träger | ST_EG_001_01; Modulbau: ST_EG_A_001_01; ST = Stütze | </div>
+</details>
+</details>
+<details class="property">
+<summary>Einzuhaltende Baustoffklasse von Oberflächen (DIN EN 13501)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> A1, A2, B, C, D, E, F, A2-s1,d0, A2-s1,d1, A2-s2,d0, A2-s2,d1, B-s1,d0, B-s1,d1, B-s2,d0, B-s2,d1, C-s1,d0, C-s1,d1, C-s2,d0, C-s2,d1, D-s1,d0, D-s1,d1, D-s2,d0, D-s2,d1</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Klassifizierung der Oberflächenmaterialien nach ihrem Brandverhalten gemäß DIN EN 13501-1</div>
+</details>
+</details>
+<details class="property">
+<summary>Einzuhaltende Klasse der Brandschutzbekleidung ( DIN EN 13501)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> K1 10, K1 30, K1 60, K2 10, K2 30, K2 60, K2 90, K2 120</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Klassifizierung der Schutzdauer durch eine Brandschutzbekleidung gemäß DIN EN 13501-2. Die Zahl gibt die minimale Dauer in Minuten an, für die die Bekleidung die Temperaturerhöhung am Bauteil begrenzt</div>
+</details>
+</details>
+<details class="property">
+<summary>Einzuhaltende Feuerwiderstandsklasse (Türen/Fenster) (DIN EN 13501)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> E 15-C0-Sa, E 15-C0-S200, E 15-C1-Sa, E 15-C1-S200, E 15-C2-Sa, E 15-C2-S200, E 15-C3-Sa, E 15-C3-S200, E 15-C4-Sa, E 15-C4-S200, E 15-C5-Sa, E 15-C5-S200, E 20-C0-Sa, E 20-C0-S200, E 20-C1-Sa, E 20-C1-S200, E 20-C2-Sa, E 20-C2-S200, E 20-C3-Sa, E 20-C3-S200, E 20-C4-Sa, E 20-C4-S200, E 20-C5-Sa, E 20-C5-S200, E 30-C0-Sa, E 30-C0-S200, E 30-C1-Sa, E 30-C1-S200, E 30-C2-Sa, E 30-C2-S200, E 30-C3-Sa, E 30-C3-S200, E 30-C4-Sa, E 30-C4-S200, E 30-C5-Sa, E 30-C5-S200, E 45-C0-Sa, E 45-C0-S200, E 45-C1-Sa, E 45-C1-S200, E 45-C2-Sa, E 45-C2-S200, E 45-C3-Sa, E 45-C3-S200, E 45-C4-Sa, E 45-C4-S200, E 45-C5-Sa, E 45-C5-S200, E 60-C0-Sa, E 60-C0-S200, E 60-C1-Sa, E 60-C1-S200, E 60-C2-Sa, E 60-C2-S200, E 60-C3-Sa, E 60-C3-S200, E 60-C4-Sa, E 60-C4-S200, E 60-C5-Sa, E 60-C5-S200, E 90-C0-Sa, E 90-C0-S200, E 90-C1-Sa, E 90-C1-S200, E 90-C2-Sa, E 90-C2-S200, E 90-C3-Sa, E 90-C3-S200, E 90-C4-Sa, E 90-C4-S200, E 90-C5-Sa, E 90-C5-S200, E 120-C0-Sa, E 120-C0-S200, E 120-C1-Sa, E 120-C1-S200, E 120-C2-Sa, E 120-C2-S200, E 120-C3-Sa, E 120-C3-S200, E 120-C4-Sa, E 120-C4-S200, E 120-C5-Sa, E 120-C5-S200, E 180-C0-Sa, E 180-C0-S200, E 180-C1-Sa, E 180-C1-S200, E 180-C2-Sa, E 180-C2-S200, E 180-C3-Sa, E 180-C3-S200, E 180-C4-Sa, E 180-C4-S200, E 180-C5-Sa, E 180-C5-S200, E 240-C0-Sa, E 240-C0-S200, E 240-C1-Sa, E 240-C1-S200, E 240-C2-Sa, E 240-C2-S200, E 240-C3-Sa, E 240-C3-S200, E 240-C4-Sa, E 240-C4-S200, E 240-C5-Sa, E 240-C5-S200, EW 15-C0-Sa, EW 15-C0-S200, EW 15-C1-Sa, EW 15-C1-S200, EW 15-C2-Sa, EW 15-C2-S200, EW 15-C3-Sa, EW 15-C3-S200, EW 15-C4-Sa, EW 15-C4-S200, EW 15-C5-Sa, EW 15-C5-S200, EW 20-C0-Sa, EW 20-C0-S200, EW 20-C1-Sa, EW 20-C1-S200, EW 20-C2-Sa, EW 20-C2-S200, EW 20-C3-Sa, EW 20-C3-S200, EW 20-C4-Sa, EW 20-C4-S200, EW 20-C5-Sa, EW 20-C5-S200, EW 30-C0-Sa, EW 30-C0-S200, EW 30-C1-Sa, EW 30-C1-S200, EW 30-C2-Sa, EW 30-C2-S200, EW 30-C3-Sa, EW 30-C3-S200, EW 30-C4-Sa, EW 30-C4-S200, EW 30-C5-Sa, EW 30-C5-S200, EW 45-C0-Sa, EW 45-C0-S200, EW 45-C1-Sa, EW 45-C1-S200, EW 45-C2-Sa, EW 45-C2-S200, EW 45-C3-Sa, EW 45-C3-S200, EW 45-C4-Sa, EW 45-C4-S200, EW 45-C5-Sa, EW 45-C5-S200, EW 60-C0-Sa, EW 60-C0-S200, EW 60-C1-Sa, EW 60-C1-S200, EW 60-C2-Sa, EW 60-C2-S200, EW 60-C3-Sa, EW 60-C3-S200, EW 60-C4-Sa, EW 60-C4-S200, EW 60-C5-Sa, EW 60-C5-S200, EW 90-C0-Sa, EW 90-C0-S200, EW 90-C1-Sa, EW 90-C1-S200, EW 90-C2-Sa, EW 90-C2-S200, EW 90-C3-Sa, EW 90-C3-S200, EW 90-C4-Sa, EW 90-C4-S200, EW 90-C5-Sa, EW 90-C5-S200, EW 120-C0-Sa, EW 120-C0-S200, EW 120-C1-Sa, EW 120-C1-S200, EW 120-C2-Sa, EW 120-C2-S200, EW 120-C3-Sa, EW 120-C3-S200, EW 120-C4-Sa, EW 120-C4-S200, EW 120-C5-Sa, EW 120-C5-S200, EW 180-C0-Sa, EW 180-C0-S200, EW 180-C1-Sa, EW 180-C1-S200, EW 180-C2-Sa, EW 180-C2-S200, EW 180-C3-Sa, EW 180-C3-S200, EW 180-C4-Sa, EW 180-C4-S200, EW 180-C5-Sa, EW 180-C5-S200, EW 240-C0-Sa, EW 240-C0-S200, EW 240-C1-Sa, EW 240-C1-S200, EW 240-C2-Sa, EW 240-C2-S200, EW 240-C3-Sa, EW 240-C3-S200, EW 240-C4-Sa, EW 240-C4-S200, EW 240-C5-Sa, EW 240-C5-S200, EI1 15-C0-Sa, EI1 15-C0-S200, EI1 15-C1-Sa, EI1 15-C1-S200, EI1 15-C2-Sa, EI1 15-C2-S200, EI1 15-C3-Sa, EI1 15-C3-S200, EI1 15-C4-Sa, EI1 15-C4-S200, EI1 15-C5-Sa, EI1 15-C5-S200, EI1 20-C0-Sa, EI1 20-C0-S200, EI1 20-C1-Sa, EI1 20-C1-S200, EI1 20-C2-Sa, EI1 20-C2-S200, EI1 20-C3-Sa, EI1 20-C3-S200, EI1 20-C4-Sa, EI1 20-C4-S200, EI1 20-C5-Sa, EI1 20-C5-S200, EI1 30-C0-Sa, EI1 30-C0-S200, EI1 30-C1-Sa, EI1 30-C1-S200, EI1 30-C2-Sa, EI1 30-C2-S200, EI1 30-C3-Sa, EI1 30-C3-S200, EI1 30-C4-Sa, EI1 30-C4-S200, EI1 30-C5-Sa, EI1 30-C5-S200, EI1 45-C0-Sa, EI1 45-C0-S200, EI1 45-C1-Sa, EI1 45-C1-S200, EI1 45-C2-Sa, EI1 45-C2-S200, EI1 45-C3-Sa, EI1 45-C3-S200, EI1 45-C4-Sa, EI1 45-C4-S200, EI1 45-C5-Sa, EI1 45-C5-S200, EI1 60-C0-Sa, EI1 60-C0-S200, EI1 60-C1-Sa, EI1 60-C1-S200, EI1 60-C2-Sa, EI1 60-C2-S200, EI1 60-C3-Sa, EI1 60-C3-S200, EI1 60-C4-Sa, EI1 60-C4-S200, EI1 60-C5-Sa, EI1 60-C5-S200, EI1 90-C0-Sa, EI1 90-C0-S200, EI1 90-C1-Sa, EI1 90-C1-S200, EI1 90-C2-Sa, EI1 90-C2-S200, EI1 90-C3-Sa, EI1 90-C3-S200, EI1 90-C4-Sa, EI1 90-C4-S200, EI1 90-C5-Sa, EI1 90-C5-S200, EI1 120-C0-Sa, EI1 120-C0-S200, EI1 120-C1-Sa, EI1 120-C1-S200, EI1 120-C2-Sa, EI1 120-C2-S200, EI1 120-C3-Sa, EI1 120-C3-S200, EI1 120-C4-Sa, EI1 120-C4-S200, EI1 120-C5-Sa, EI1 120-C5-S200, EI1 180-C0-Sa, EI1 180-C0-S200, EI1 180-C1-Sa, EI1 180-C1-S200, EI1 180-C2-Sa, EI1 180-C2-S200, EI1 180-C3-Sa, EI1 180-C3-S200, EI1 180-C4-Sa, EI1 180-C4-S200, EI1 180-C5-Sa, EI1 180-C5-S200, EI1 240-C0-Sa, EI1 240-C0-S200, EI1 240-C1-Sa, EI1 240-C1-S200, EI1 240-C2-Sa, EI1 240-C2-S200, EI1 240-C3-Sa, EI1 240-C3-S200, EI1 240-C4-Sa, EI1 240-C4-S200, EI1 240-C5-Sa, EI1 240-C5-S200, EI2 15-C0-Sa, EI2 15-C0-S200, EI2 15-C1-Sa, EI2 15-C1-S200, EI2 15-C2-Sa, EI2 15-C2-S200, EI2 15-C3-Sa, EI2 15-C3-S200, EI2 15-C4-Sa, EI2 15-C4-S200, EI2 15-C5-Sa, EI2 15-C5-S200, EI2 20-C0-Sa, EI2 20-C0-S200, EI2 20-C1-Sa, EI2 20-C1-S200, EI2 20-C2-Sa, EI2 20-C2-S200, EI2 20-C3-Sa, EI2 20-C3-S200, EI2 20-C4-Sa, EI2 20-C4-S200, EI2 20-C5-Sa, EI2 20-C5-S200, EI2 30-C0-Sa, EI2 30-C0-S200, EI2 30-C1-Sa, EI2 30-C1-S200, EI2 30-C2-Sa, EI2 30-C2-S200, EI2 30-C3-Sa, EI2 30-C3-S200, EI2 30-C4-Sa, EI2 30-C4-S200, EI2 30-C5-Sa, EI2 30-C5-S200, EI2 45-C0-Sa, EI2 45-C0-S200, EI2 45-C1-Sa, EI2 45-C1-S200, EI2 45-C2-Sa, EI2 45-C2-S200, EI2 45-C3-Sa, EI2 45-C3-S200, EI2 45-C4-Sa, EI2 45-C4-S200, EI2 45-C5-Sa, EI2 45-C5-S200, EI2 60-C0-Sa, EI2 60-C0-S200, EI2 60-C1-Sa, EI2 60-C1-S200, EI2 60-C2-Sa, EI2 60-C2-S200, EI2 60-C3-Sa, EI2 60-C3-S200, EI2 60-C4-Sa, EI2 60-C4-S200, EI2 60-C5-Sa, EI2 60-C5-S200, EI2 90-C0-Sa, EI2 90-C0-S200, EI2 90-C1-Sa, EI2 90-C1-S200, EI2 90-C2-Sa, EI2 90-C2-S200, EI2 90-C3-Sa, EI2 90-C3-S200, EI2 90-C4-Sa, EI2 90-C4-S200, EI2 90-C5-Sa, EI2 90-C5-S200, EI2 120-C0-Sa, EI2 120-C0-S200, EI2 120-C1-Sa, EI2 120-C1-S200, EI2 120-C2-Sa, EI2 120-C2-S200, EI2 120-C3-Sa, EI2 120-C3-S200, EI2 120-C4-Sa, EI2 120-C4-S200, EI2 120-C5-Sa, EI2 120-C5-S200, EI2 180-C0-Sa, EI2 180-C0-S200, EI2 180-C1-Sa, EI2 180-C1-S200, EI2 180-C2-Sa, EI2 180-C2-S200, EI2 180-C3-Sa, EI2 180-C3-S200, EI2 180-C4-Sa, EI2 180-C4-S200, EI2 180-C5-Sa, EI2 180-C5-S200, EI2 240-C0-Sa, EI2 240-C0-S200, EI2 240-C1-Sa, EI2 240-C1-S200, EI2 240-C2-Sa, EI2 240-C2-S200, EI2 240-C3-Sa, EI2 240-C3-S200, EI2 240-C4-Sa, EI2 240-C4-S200, EI2 240-C5-Sa, EI2 240-C5-S200</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Klassifizierung des Feuerwiderstands von Türen, Abschlüssen und zu öffnenden Fenstern gemäß DIN EN 13501-2. Gibt an, wie lange das Bauteil im Brandfall funktional bleibt. Z.B. EI2 30-C5-S200</div>
+</details>
+</details>
+<details class="property">
+<summary>Festigkeitsklasse (ETA)</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Produktbezogene Festigkeitsangabe gemäß Europäischer Technischer Bewertung (ETA), z. B. durch Plattenklassen wie OSB/3 oder durch Einzelkennwerte wie „fk = 20 N/mm²“ in Verbindung mit der ETA-Nummer (z. B. ETA-03/0033)</div>
+</details>
+</details>
+<details class="property">
+<summary>Festigkeitsklasse (DIN EN 338/14080)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> C16, C24, C30, C35, D30, D35, D40, D60, GL24h, GL24c, GL28h, GL28c, GL30h, GL30c, GL32h, GL32c</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Klassifizierung von Vollholz und Brettschichtholz nach charakteristischen Festigkeitswerten gemäß DIN EN 338 bzw. DIN EN 14080</div>
+</details>
+</details>
+<details class="property">
+<summary>Feuerwiderstandsklasse (DIN EN 13501)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> RE  15, 20, 30, 45, 60, 90, 120, 180, 240, 360
+REI 15, 20, 30, 45, 60, 90, 120, 180, 240, 360</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Tatsächlich umgesetzte Feuerwiderstandsklasse des ausgeführten Bauteils basierend auf Prüfzeugnissen, Systemnachweisen oder technischen Nachweisen.</div>
+</details>
+</details>
+<details class="property">
+<summary>Gebrauchsklasse (nach DIN EN 1995 / Eurocode 5)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> Gebrauchsklasse 0 (GK 0), Gebrauchsklasse 1 (GK 1), Gebrauchsklasse 2 (GK 2), Gebrauchsklasse 3.1 (GK 3.1), Gebrauchsklasse 3.2 (GK 3.2), Gebrauchsklasse 4 (GK 4), Gebrauchsklasse 5 (GK 5)</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Klassifizierung der Einwirkung von Feuchtigkeit auf einzelne Holzbauteile innerhalb eines Elements. Die Gebrauchsklasse beschreibt die dauerhafte Einbausituation des Materials, nicht das gesamte Bauteil</div>
+</details>
+</details>
+<details class="property">
+<summary>Geschoss</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>UG, EG, 1OG, 2OG, 3OG, …</div>
+</details>
+</details>
+<details class="property">
+<summary>Gewicht des Elements</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kg]</div>
+</details>
+<details class="property">
+<summary>Hersteller/Produkt</summary>
+</details>
+<details class="property">
+<summary>Herstellkosten</summary>
+<div class="prop-content"><strong>Einheit:</strong> [€]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Monetärer Aufwand für die Herstellung eines Bauteils inklusive Material, Fertigung und Einbau – angegeben in €</div>
+</details>
+</details>
+<details class="property">
+<summary>Holzart</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> Fichte, Tanne, Lärche, Eiche, Buche, Kiefer, Ahorn, Esche, Akazie, Erle, Douglasie, Birke, Walnuss, Kirsche</div>
+</details>
+<details class="property">
+<summary>Konstruktionsart</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Holzrahmen, Sichtbalken, Brettschichtholz, Brettstapel, Holzbetonverbund</div>
+</details>
+</details>
+<details class="property">
+<summary>Kostengruppe (DIN 276)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> XXX</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Z.B. 332 (nichttragende Innenwand)</div>
+</details>
+</details>
+<details class="property">
+<summary>Lebenszyklus Nutzungsdauer in Jahren</summary>
+<div class="prop-content"><strong>Einheit:</strong> [Jahre]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Angabe der erwarteten Nutzungsdauer eines Bauteils in Jahren</div>
+</details>
+</details>
+<details class="property">
+<summary>Leistungsbereiche nach VOB</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> 18299 Allgemeine Regelungen für Bauarbeiten jeder Art, 18300 Erdarbeiten, 18301 Bohrarbeiten, 18302 Arbeiten zum Ausbau von Bohrungen, 18303 Verbauarbeiten, 18304 Ramm-, Rüttel- und Pressarbeiten, 18305 Wasserhaltungsarbeiten, 18306 Entwässerungskanalarbeiten, 18307 Druckrohrleitungsarbeiten außerhalb von Gebäuden, 18308 Drän- und Versickerarbeiten, 18309 Einpressarbeiten, 18311 Nassbaggerarbeiten, 18312 Untertagebauarbeiten, 18313 Schlitzwandarbeiten mit stützenden Flüssigkeiten, 18314 Spritzbetonarbeiten, 18315 Verkehrswegebauarbeiten – Oberbauschichten ohne Bindemittel, 18316 Verkehrswegebauarbeiten – Oberbauschichten mit hydraulischen Bindemitteln, 18317 Verkehrswegebauarbeiten – Oberbauschichten aus Asphalt, 18318 Verkehrswegebauarbeiten – Pflasterdecken und Plattenbeläge in ungebundener Ausführung, Einfassungen, 18319 Rohrvortriebsarbeiten, 18320 Landschaftsbauarbeiten, 18321 Düsenstrahlarbeiten, 18322 Kabelleitungstiefbauarbeiten, 18323 Kampfmittelräumarbeiten, 18324 Horizontalspülbohrarbeiten, 18325 Gleisbauarbeiten, 18326 Renovierungsarbeiten an Entwässerungskanälen, 18329 Verkehrssicherungsarbeiten, 18330 Mauerarbeiten, 18331 Betonarbeiten, 18332 Naturwerksteinarbeiten, 18334 Zimmer- und Holzbauarbeiten, 18335 Stahlbauarbeiten, 18336 Abdichtungsarbeiten, 18338 Dachdeckungs- und Dachabdichtungsarbeiten, 18339 Klempnerarbeiten, 18340 Trockenbauarbeiten, 18345 Wärmedämm-Verbundsysteme, 18349 Betonerhaltungsarbeiten, 18350 Putz- und Stuckarbeiten, 18351 Vorgehängte Hinterlüftete Fassaden, 18352 Fliesen- und Plattenarbeiten, 18353 Estricharbeiten, 18354 Gussasphaltarbeiten, 18355 Tischlerarbeiten, 18356 Parkett- und Holzpflasterarbeiten, 18357 Beschlagarbeiten, 18358 Rollladenarbeiten, 18360 Metallbauarbeiten, 18361 Verglasungsarbeiten, 18363 Maler- und Lackierarbeiten – Beschichtungen, 18364 Korrosionsschutzarbeiten an Stahlbauten, 18365 Bodenbelagarbeiten, 18366 Tapezierarbeiten, 18379 Raumlufttechnische Anlagen, 18380 Heizanlagen und zentrale Wassererwärmungsanlagen, 18381 Gas-, Wasser- und Entwässerungsanlagen innerhalb von Gebäuden, 18382 Nieder- und Mittelspannungsanlagen mit Nennspannungen bis 36 kV, 18384 Blitzschutzanlagen, 18385 Aufzugsanlagen, Fahrtreppen und Fahrsteige sowie Förderanlagen, 18386 Gebäudeautomation, 18421 Dämm- und Brandschutzarbeiten an technischen Anlagen, 18451 Gerüstarbeiten, 18459 Abbruch- und Rückbauarbeiten</div>
+</details>
+<details class="property">
+<summary>Luftschalldämmung Rʹw erforderlich (DIN 4109)</summary>
+<div class="prop-content"><strong>Einheit:</strong> [dB]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Erforderliches bewertetes Schalldämm-Maß Rʹw in dB gemäß DIN 4109</div>
+</details>
+</details>
+<details class="property">
+<summary>Luftschalldämmung Rʹw nachgewiesen (DIN 4109)</summary>
+<div class="prop-content"><strong>Einheit:</strong> [dB]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Nachgewiesenes bewertetes Schalldämm-Maß Rʹw in dB aus bauakustischer Berechnung oder Messung</div>
+</details>
+</details>
+<details class="property">
+<summary>Nutzungskategorie (DIN EN 1991-1-1)
+</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> Kategorie A, Kategorie B, Kategorie C1, Kategorie C2, Kategorie C3, Kategorie C4, Kategorie C5, Kategorie D1, Kategorie D2, Kategorie E, Kategorie F</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Klassifizierung der Raumnutzung zur Festlegung von Verkehrslasten gemäß DIN EN 1991-1-1. Wird auf Räume und Nutzungseinheiten angewendet</div>
+</details>
+</details>
+<details class="property">
+<summary>Nutzungsklasse (DIN 1052)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> Nutzungsklasse 1 (NKL 1), Nutzungsklasse 2 (NKL 2), Nutzungsklasse 3 (NKL 3)</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Klassifizierung der Umgebungsbedingungen eines Elements (z. B. Wand, Decke, Dach) im Hinblick auf die Einwirkungen auf Holzbauteile. Die Nutzungsklasse bezieht sich auf das gesamte Bauteil bzw. die Bauumgebung gemäß DIN 1052</div>
+</details>
+</details>
+<details class="property">
+<summary>Material</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Brettsperrholz</div>
+</details>
+</details>
+<details class="property">
+<summary>Oberflächenqualität (Qualität)</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Nsi (Nicht sichtbar), Si (sichtbar)</div>
+</details>
+</details>
+<details class="property">
+<summary>Oberflächenbehandlung</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Z.B. UV-Lasur, Brandschutzanstrich, RALXXXX</div>
+</details>
+</details>
+<details class="property">
+<summary>Ökobilanzierungs - ID</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Datensatz-ID der Ökobilanzdatenbank z.B. 3a7b1543-dc36-4b1f-8c51-0a20409dbd94</div>
+</details>
+</details>
+<details class="property">
+<summary>Primärenergiebedarf nicht erneuerbar (PENRT) Bauteil</summary>
+<div class="prop-content"><strong>Einheit:</strong> [MJ/Bauteil]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Pro Bauteil</div>
+</details>
+</details>
+<details class="property">
+<summary>Primärenergiebedarf nicht erneuerbar (PENRT) Fläche</summary>
+<div class="prop-content"><strong>Einheit:</strong> [MJ/m2]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Pro m2</div>
+</details>
+</details>
+<details class="property">
+<summary>Primärenergiebedarf nicht erneuerbar (PENRT) Gewicht</summary>
+<div class="prop-content"><strong>Einheit:</strong> [MJ/kg]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Pro kg</div>
+</details>
+</details>
+<details class="property">
+<summary>Positionsbezeichnung TWP</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>01,02,03,04,05, …</div>
+</details>
+</details>
+<details class="property">
+<summary>Produktionsnummer</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>01,02,03,04,05, …</div>
+</details>
+</details>
+<details class="property">
+<summary>Rückbaubarkeit</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> vollständig rückbaubar, teilweise rückbaubar, nicht rückbaubar</div>
+</details>
+<details class="property">
+<summary>Rohdichte (DIN 68364)</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kg/m3]</div>
+</details>
+<details class="property">
+<summary>Schichtstärke</summary>
+<div class="prop-content"><strong>Einheit:</strong> [mm]</div>
+</details>
+<details class="property">
+<summary>Thermisch/nicht thermisch</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> thermisch/nicht thermisch</div>
+</details>
+<details class="property">
+<summary>Tragend/nicht tragend</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> tragend/nicht tragend</div>
+</details>
+<details class="property">
+<summary>Transportnummer</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>01,02,03,04,05, …</div>
+</details>
+</details>
+<details class="property">
+<summary>Teil der Luftdichten Ebene</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> Ja/Nein</div>
+</details>
+<details class="property">
+<summary>Treibhausgaspotenzial (GWP) Bauteil</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kg CO2-eq/Bauteil]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Pro Bauteil</div>
+</details>
+</details>
+<details class="property">
+<summary>Treibhausgaspotenzial (GWP) Fläche</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kg CO2-eq/m2]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Pro m2</div>
+</details>
+</details>
+<details class="property">
+<summary>Treibhausgaspotenzial (GWP) Gewicht</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kg CO2-eq/kg]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Pro kg</div>
+</details>
+</details>
+<details class="property">
+<summary>Trittschalldämmung L’n,w erforderlich (DIN 4109)</summary>
+<div class="prop-content"><strong>Einheit:</strong> [dB]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Zulässiger bewerteter Norm-Trittschallpegel L’n,w in dB gemäß DIN 4109. Gibt die maximal erlaubte Trittschallübertragung durch Decken oder Bauteile an</div>
+</details>
+</details>
+<details class="property">
+<summary>Trittschalldämmung L’n,w nachgewiesen (DIN 4109)</summary>
+<div class="prop-content"><strong>Einheit:</strong> [dB]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Gemessener oder berechneter bewerteter Norm-Trittschallpegel L’n,w in dB gemäß DIN 4109. Dient dem Nachweis, dass das Bauteil die geforderte Trittschalldämmung erfüllt</div>
+</details>
+</details>
+<details class="property">
+<summary>Trennwandzuschlag (DIN EN 1991)</summary>
+<div class="prop-content"><strong>Einheit:</strong> [kN/m2]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Zuschlaglast in kN/m² gemäß DIN EN 1991-1-1 zur Berücksichtigung potenzieller Trennwände auf Deckenflächen</div>
+</details>
+</details>
+<details class="property">
+<summary>U-Wert </summary>
+<div class="prop-content"><strong>Einheit:</strong> [W/(m2*K]</div>
+</details>
+<details class="property">
+<summary>Zonenbegrenzung</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> beheizt ↔ außen, beheizt ↔ unbeheizt, beheizt ↔ Erdreich, beheizt ↔ außen (auskragend), außen ↔ außen (auskragender Balkon), unbeheizt ↔ außen, unbeheizt ↔ Erdreich, unbeheizt ↔ unbeheizt, beheizt ↔ beheizt, beheizt ↔ außenliegender Sonnenschutz</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Die Zonenbegrenzung beschreibt, welche Bereiche durch ein Bauteil thermisch voneinander getrennt werden. Dabei wird die innere Zone (z. B. beheizt oder unbeheizt innerhalb des Gebäudes) immer zuerst genannt, die äußere Umgebung oder angrenzende Zone folgt</div>
+</details>
+</details>
+<details class="property">
+<summary>Wartungspflicht</summary>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Gibt an, ob das Bauteil regelmäßig gewartet werden muss (z. B. gemäß Herstellerangaben, DIN-Normen oder technischer Funktion)</div>
+</details>
+</details>
+<details class="property">
+<summary>Wasserdampfdiffusionswiderstand (DIN EN 10456)</summary>
+<div class="prop-content"><strong>Einheit:</strong>  [m]</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Widerstand eines Bauteils gegen den Durchtritt von Wasserdampf, ausgedrückt als Sd-Wert in Metern gemäß DIN EN 10456</div>
+</details>
+</details>
+<details class="property">
+<summary>Wärmeleitfähigkeit</summary>
+<div class="prop-content"><strong>Einheit:</strong> λ [W/(m*K]</div>
+</details>
+<details class="property">
+<summary>Widerstandsklasse (Einbruchhemmung) (DIN EN 1627)</summary>
+<div class="prop-content"><strong>Gelistete Werte:</strong> RC 1 N, RC 2 N, RC 2, RC 3, RC 4, RC 5, RC 6</div>
+<details class="prop-content"><summary>Anmerkung</summary>
+<div>Klassifizierung einbruchhemmender Bauteile (z. B. Fenster, Türen) gemäß DIN EN 1627</div>
+</details>
+</details>
+</details>
+</body></html>


### PR DESCRIPTION
## Summary
- generate `attribute-uebersicht.html` from the Excel file using a pure Python parser
- restructure HTML with nested details per property and remove the data type column

## Testing
- `python3 - <<'PY'
import zipfile, xml.etree.ElementTree as ET
print(len(zipfile.ZipFile('Excel für codex.xlsx').namelist()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_685d39dcf3b08325bc223692b0088fb6